### PR TITLE
chore: add comment back

### DIFF
--- a/src/v2/controllers/vdeployment_controller/trusted/spec_types.rs
+++ b/src/v2/controllers/vdeployment_controller/trusted/spec_types.rs
@@ -120,6 +120,7 @@ impl ResourceView for VDeploymentView {
     open spec fn state_validation(self) -> bool {
         // replicas is non-negative
         &&& self.spec.replicas.is_Some() ==> self.spec.replicas.get_Some_0() >= 0
+        // selector exists, and its match_labels is not empty
         // TODO: revise it after supporting selector.match_expressions
         &&& self.spec.selector.match_labels.is_Some()
         &&& self.spec.selector.match_labels.get_Some_0().len() > 0


### PR DESCRIPTION
missing comment from original deployment spec