### PR TITLE
fix: statefulset state_validation function

### DIFF
--- a/src/v2/controllers/vstatefulset_controller/trusted/spec_types.rs
+++ b/src/v2/controllers/vstatefulset_controller/trusted/spec_types.rs
@@ -1,9 +1,5 @@
 /*
 open spec fn state_validation(self) -> bool {
-    // serviceName must not be empty
-    &&& self.spec.service_name.is_Some()
-    ==> self.spec.service_name.get_Some_0().len() > 0
-
     // selector exists, and its match_labels is not empty
     // TODO: revise it after supporting selector.match_expressions
     &&& self.spec.selector.match_labels.is_Some()

--- a/src/v2/controllers/vstatefulset_controller/trusted/spec_types.rs
+++ b/src/v2/controllers/vstatefulset_controller/trusted/spec_types.rs
@@ -1,8 +1,8 @@
 /*
 open spec fn state_validation(self) -> bool {
-    // serviceName is required and must not be empty
+    // serviceName must not be empty
     &&& self.spec.service_name.is_Some()
-    &&& self.spec.service_name.get_Some_0().len() > 0
+    ==> self.spec.service_name.get_Some_0().len() > 0
 
     // selector exists, and its match_labels is not empty
     // TODO: revise it after supporting selector.match_expressions
@@ -23,46 +23,52 @@ open spec fn state_validation(self) -> bool {
         // updateStrategy.type must be either RollingUpdate or OnDelete (used "type_" to avoid clashing with Rust keyword)
         self.spec.update_strategy.get_Some_0().type_.is_Some() ==>
         match self.spec.update_strategy.get_Some_0().type_.get_Some_0() {
-        "RollingUpdate"@ => self.spec.update_strategy.get_Some_0().rolling_update.is_Some() ==> (
-                                // updateStrategy.rollingUpdate.partition is non-negative
-                                self.spec.update_strategy.get_Some_0().rolling_update.get_Some_0().partition.is_Some() ==>
-                                self.spec.update_strategy.get_Some_0().rolling_update.get_Some_0().partition.get_Some_0() >= 0
-                                // if updateStrategy.rollingUpdate.maxUnavailable is present, validate it's positive (assuming its an integer for now)
-                                &&& self.spec.update_strategy.get_Some_0().rolling_update.get_Some_0().max_unavailable.is_Some() ==>
-                                self.spec.update_strategy.get_Some_0().rolling_update.get_Some_0().max_unavailable.get_Some_0() > 0
-                            )
-        // updateStrategy.rollingUpdate is None if updateStrategy.type is OnDelete
-        "OnDelete"@ => self.spec.update_strategy.get_Some_0().rolling_update.is_None(),
-        _ => false
-    }
+            "RollingUpdate"@ => self.spec.update_strategy.get_Some_0().rolling_update.is_Some() ==> (
+                                    // updateStrategy.rollingUpdate.partition is non-negative
+                                    self.spec.update_strategy.get_Some_0().rolling_update.get_Some_0().partition.is_Some() ==>
+                                    self.spec.update_strategy.get_Some_0().rolling_update.get_Some_0().partition.get_Some_0() >= 0
+                                    // if updateStrategy.rollingUpdate.maxUnavailable is present, validate it's positive (assuming its an integer for now)
+                                    &&& self.spec.update_strategy.get_Some_0().rolling_update.get_Some_0().max_unavailable.is_Some() ==>
+                                    self.spec.update_strategy.get_Some_0().rolling_update.get_Some_0().max_unavailable.get_Some_0() > 0
+                                )
+            // updateStrategy.rollingUpdate is None if updateStrategy.type is OnDelete
+            "OnDelete"@ => self.spec.update_strategy.get_Some_0().rolling_update.is_None(),
+            _ => false
+        }
+    )
 
     // podManagementPolicy must be either OrderedReady or Parallel
     &&& self.spec.pod_management_policy.is_Some() ==>
     self.spec.pod_management_policy.get_Some_0() == "OrderedReady"@
     || self.spec.pod_management_policy.get_Some_0() == "Parallel"@
 
-    // revisionHistoryLimit must be non‑negative if present
-    &&& self.spec.revision_history_limit.is_Some() ==>
-    self.spec.revision_history_limit.get_Some_0() >= 0
 
     // volumeClaimTemplates
     // TODO: this object is too big, assume state_validation() is implemented for PersistentVolumeClaimSpec for now
+    // TODO: volumeClaimTemplates is actually a list
     &&& self.spec.volume_claim_templates.is_Some() ==>
-    self.spec.volume_claim_templates.state_validation()
+    self.spec.volume_claim_templates.get_Some_0().state_validation()
 
     // minReadySeconds must be non‑negative if present
     &&& self.spec.min_ready_seconds.is_Some() ==>
     self.spec.min_ready_seconds.get_Some_0() >= 0
 
     // persistentVolumeClaimRetentionPolicy.whenDeleted/whenScaled must be Delete or Retain
-    &&& self.spec.persistent_volume_claim_retention_policy.is_Some() ==>
-    self.spec.persistent_volume_claim_retention_policy.get_Some_0().when_deleted == "Delete"@
-    || self.spec.persistent_volume_claim_retention_policy.get_Some_0().when_deleted == "Retain"@
-    &&& self.spec.persistent_volume_claim_retention_policy.get_Some_0().when_scaled  == "Delete"@
-    || self.spec.persistent_volume_claim_retention_policy.get_Some_0().when_scaled  == "Retain"@
+    &&& self.spec.persistent_volume_claim_retention_policy.is_Some() ==> (
+        self.spec.persistent_volume_claim_retention_policy.get_Some_0().when_deleted.is_Some() ==> (
+            self.spec.persistent_volume_claim_retention_policy.get_Some_0().when_deleted.get_Some_0() == "Delete"@
+            || self.spec.persistent_volume_claim_retention_policy.get_Some_0().when_deleted.get_Some_0() == "Retain"@
+        )
+        self.spec.persistent_volume_claim_retention_policy.get_Some_0().when_scaled.is_Some() ==> (
+            self.spec.persistent_volume_claim_retention_policy.get_Some_0().when_scaled.get_Some_0() == "Delete"@
+            || self.spec.persistent_volume_claim_retention_policy.get_Some_0().when_scaled.get_Some_0() == "Retain"@
+        )
+    )
 
     // ordinals.start must be non‑negative if ordinals is provided
-    &&& self.spec.ordinals.is_Some() ==>
-    self.spec.ordinals.get_Some_0().start >= 0
+    &&& self.spec.ordinals.is_Some() ==> (
+        self.spec.ordinals.get_Some_0().start.is_Some() ==>
+        self.spec.ordinals.get_Some_0().start.get_Some_0() >= 0
+    )
 }
 */


### PR DESCRIPTION
Found various mistakes in the proposed spec:
1. serviceName is not required and can even be empty
2. Missing ")"
3. revisionHistoryLimit can be any integer
4. Minor fix and comments on volume_claim_templates
5. is_some get_some logic for persistentVolumeClaim... and ordinals.start